### PR TITLE
Increments plays when playing, not on pause

### DIFF
--- a/src/store.mjs
+++ b/src/store.mjs
@@ -212,10 +212,10 @@ export default function createStore (render, onPendingChange = () => {}) {
           player.load(midi.downloadUrl)
           player.play()
           store.player.currentSlug = midiSlug
+          midi.plays += 1 // Optimistically update local play count
         }
 
         api.midi.play({ slug: midiSlug }) // Track play count
-        midi.plays += 1 // Optimistically update local play count
 
         return update()
       }


### PR DESCRIPTION
Totally speculative PR (as can't run it locally without secrets) but was on bitmidi.com and noticed the plays were being incremented on pause as well as on play. 

This looks about right but feel free to close if not. :+1: