### PR TITLE
Return all midis including search query, not only whole-word matches

### DIFF
--- a/src/api/midi.mjs
+++ b/src/api/midi.mjs
@@ -89,7 +89,7 @@ async function search (query = {}) {
     .query()
     .skipUndefined()
     .select(query.select)
-    .whereRaw('MATCH(name) AGAINST(? IN NATURAL LANGUAGE MODE)', query.q)
+    .where('name', 'like', `%${query.q}%`)
     .page(query.page, query.pageSize)
 
   return { query, results, total, pageTotal: getPageTotal(total, query.pageSize) }


### PR DESCRIPTION
So the search currently only returns midis whose titles have at least one whole word match, i.e. 

Searching for `moon` will return `Howling At The Moon` but not `Moonlight Sonata`.

IMHO, it makes way more sense to return all midis whose title includes the search query as the search is kind of inconvenient if you can only search in whole-word-matches. My change will now return all these matches.